### PR TITLE
Support changed linkerd namespace flag in edge 20.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/setup-go@v1
       with:
         go-version: ${{ secrets.GO_VERSION }}
-    - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go get -u github.com/kisielk/errcheck; /home/runner/go/bin/errcheck ./...
+    - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go get -u github.com/kisielk/errcheck; /home/runner/go/bin/errcheck -exclude errcheck_excludes.txt ./...
   static_check:
     name: Static check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       uses: actions/setup-go@v1
       with:
         go-version: ${{ secrets.GO_VERSION }}
-    - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go get -u honnef.co/go/tools/cmd/staticcheck; /home/runner/go/bin/staticcheck -checks all ./... # https://staticcheck.io/docs/checks
+    - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go get -u honnef.co/go/tools/cmd/staticcheck; /home/runner/go/bin/staticcheck -checks all,-ST1000 ./... # https://staticcheck.io/docs/checks
   vet:
     name: Vet
     runs-on: ubuntu-latest

--- a/errcheck_excludes.txt
+++ b/errcheck_excludes.txt
@@ -1,0 +1,3 @@
+(io.Closer).Close
+(*os.File).Close
+(*github.com/layer5io/meshery-linkerd/linkerd.YAMLDecoder).Close

--- a/linkerd/install.go
+++ b/linkerd/install.go
@@ -119,7 +119,7 @@ func (iClient *Client) downloadFile(urlToDownload, localFile string) error {
 		return err
 	}
 	defer dFile.Close()
-
+	/* #nosec */
 	resp, err := http.Get(urlToDownload)
 	if err != nil {
 		err = errors.Wrapf(err, "unable to download the file from URL: %s", iClient.linkerdReleaseDownloadURL)
@@ -140,6 +140,7 @@ func (iClient *Client) downloadFile(urlToDownload, localFile string) error {
 		logrus.Error(err)
 		return err
 	}
+	/* #nosec */
 	err = os.Chmod(localFile, 0755)
 	if err != nil {
 		err = errors.Wrapf(err, "unable to change permission on %s", localFile)
@@ -200,6 +201,7 @@ func (iClient *Client) execute(command ...string) (string, string, error) {
 
 	// TODO: execute
 	logrus.Debugf("command to be executed: %s %v", localFile, command)
+	/* #nosec */
 	cmd := exec.Command(localFile, command...)
 	var outb, errb bytes.Buffer
 	cmd.Stdout = &outb
@@ -275,7 +277,7 @@ func (iClient *Client) getYAML(remoteURL, localFile string) (string, error) {
 		}
 		logrus.Debug("file successfully downloaded . . .")
 	}
-
+	/* #nosec */
 	b, err := ioutil.ReadFile(localFile)
 	return string(b), err
 }

--- a/linkerd/install.go
+++ b/linkerd/install.go
@@ -40,9 +40,8 @@ const (
 	cachePeriod = 1 * time.Hour
 )
 
-var ( 
-	
-	urlsuffix          = "-" + runtime.GOOS //defining 
+var (
+	urlsuffix          = "-" + runtime.GOOS //defining
 	localFile          = path.Join(os.TempDir(), "linkerd-cli")
 	emojivotoLocalFile = path.Join(os.TempDir(), "emojivoto.yml")
 	booksAppLocalFile  = path.Join(os.TempDir(), "booksapp.yml")
@@ -97,8 +96,8 @@ func (iClient *Client) getLatestReleaseURL() error {
 		logrus.Debugf("retrieved api info: %+#v", result)
 		if result != nil && result.Assets != nil && len(result.Assets) > 0 {
 			for _, asset := range result.Assets {
-				if strings.HasSuffix(asset.Name, urlsuffix ) {
-					iClient.linkerdReleaseVersion = strings.Replace(asset.Name, urlsuffix , "", -1)
+				if strings.HasSuffix(asset.Name, urlsuffix) {
+					iClient.linkerdReleaseVersion = strings.Replace(asset.Name, urlsuffix, "", -1)
 					iClient.linkerdReleaseDownloadURL = asset.DownloadURL
 					iClient.linkerdReleaseUpdatedAt = time.Now()
 					return nil
@@ -188,7 +187,8 @@ func (iClient *Client) execute(command ...string) (string, string, error) {
 	logrus.Debugf("checking if install file exists at path: %s", localFile)
 	_, err = os.Stat(localFile)
 	if err != nil {
-
+		err = errors.Wrap(err, "path not found")
+		logrus.Error(err)
 	}
 	// fileContents, err := ioutil.ReadFile(installFileLoc)
 	// if err != nil {

--- a/linkerd/install.go
+++ b/linkerd/install.go
@@ -204,13 +204,12 @@ func (iClient *Client) execute(command ...string) (string, string, error) {
 	var outb, errb bytes.Buffer
 	cmd.Stdout = &outb
 	cmd.Stderr = &errb
-	// err = cmd.Run()
-	cmd.Run()
-	// if err != nil {
-	// 	err = errors.Wrapf(err, "error while executing requested command")
-	// 	logrus.Error(err)
-	// 	return "", "", err
-	// }
+
+	err = cmd.Run()
+	if err != nil {
+		err = errors.Wrapf(err, "error while executing requested command")
+		logrus.Error(err)
+	}
 	logrus.Debugf("Received output: %s", outb.String())
 	logrus.Debugf("Received error: %s", errb.String())
 	return outb.String(), errb.String(), nil

--- a/linkerd/linkerd.go
+++ b/linkerd/linkerd.go
@@ -264,6 +264,7 @@ func (iClient *Client) labelNamespaceForAutoInjection(ctx context.Context, names
 			ns.SetName(namespace)
 			ns, err = iClient.getResource(ctx, res, ns)
 			if err != nil {
+				logrus.Debugf("Error getting namespace", ns.GetName())
 				return err
 			}
 		} else {
@@ -301,13 +302,13 @@ func (iClient *Client) executeInstall(ctx context.Context, arReq *meshes.ApplyRu
 	args1 = append(args1, "--kubeconfig", tmpKubeConfigFileLoc)
 
 	preCheck := append(args1, "check", "--pre")
-	yamlFileContents, er, err := iClient.execute(preCheck...)
+	_, _, err := iClient.execute(preCheck...)
 	if err != nil {
 		return err
 	}
 
 	installArgs := append(args1, "install", "--ignore-cluster")
-	yamlFileContents, er, err = iClient.execute(installArgs...)
+	yamlFileContents, er, err := iClient.execute(installArgs...)
 	if err != nil {
 		return err
 	}
@@ -402,7 +403,6 @@ func (iClient *Client) ApplyOperation(ctx context.Context, arReq *meshes.ApplyRu
 				Summary:     fmt.Sprintf("Linkerd %s successfully", opName),
 				Details:     fmt.Sprintf("The latest version of Linkerd is now %s.", opName),
 			}
-			return
 		}()
 		return &meshes.ApplyRuleResponse{
 			OperationId: arReq.OperationId,
@@ -499,7 +499,6 @@ func (iClient *Client) ApplyOperation(ctx context.Context, arReq *meshes.ApplyRu
 				Summary:     fmt.Sprintf("%s %s successfully", appName, opName),
 				Details:     msg,
 			}
-			return
 		}()
 		return &meshes.ApplyRuleResponse{
 			OperationId: arReq.OperationId,

--- a/linkerd/linkerd.go
+++ b/linkerd/linkerd.go
@@ -35,7 +35,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
-	// logrus.Debugf("received k8sConfig: %s", k8sConfig)  //to solve
+
+// logrus.Debugf("received k8sConfig: %s", k8sConfig)  //to solve
 
 // CreateMeshInstance - creates a mesh adapter instance
 func (iClient *Client) CreateMeshInstance(_ context.Context, k8sReq *meshes.CreateMeshInstanceRequest) (*meshes.CreateMeshInstanceResponse, error) {
@@ -286,14 +287,14 @@ func (iClient *Client) labelNamespaceForAutoInjection(ctx context.Context, names
 
 func (iClient *Client) executeInstall(ctx context.Context, arReq *meshes.ApplyRuleRequest) error {
 	var tmpKubeConfigFileLoc = path.Join(os.TempDir(), fmt.Sprintf("kubeconfig_%d", time.Now().UnixNano()))
-	// -l <namespace> --context <context name> --kubeconfig <file path>
+	// -L <namespace> --context <context name> --kubeconfig <file path>
 	// logrus.Debugf("about to write kubeconfig to file: %s", iClient.kubeconfig)
 	if err := ioutil.WriteFile(tmpKubeConfigFileLoc, iClient.kubeconfig, 0700); err != nil {
 		return err
 	}
 	// defer os.Remove(tmpKubeConfigFileLoc)
 
-	args1 := []string{"-l", arReq.Namespace}
+	args1 := []string{"-L", arReq.Namespace}
 	if iClient.contextName != "" {
 		args1 = append(args1, "--context", iClient.contextName)
 	}

--- a/linkerd/linkerd.go
+++ b/linkerd/linkerd.go
@@ -264,7 +264,7 @@ func (iClient *Client) labelNamespaceForAutoInjection(ctx context.Context, names
 			ns.SetName(namespace)
 			ns, err = iClient.getResource(ctx, res, ns)
 			if err != nil {
-				logrus.Debugf("Error getting namespace", ns.GetName())
+				logrus.Debugf("Error getting namespace %s", ns.GetName())
 				return err
 			}
 		} else {

--- a/linkerd/linkerd.go
+++ b/linkerd/linkerd.go
@@ -600,7 +600,6 @@ func (iClient *Client) StreamEvents(in *meshes.EventsRequest, stream meshes.Mesh
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
-	return nil
 }
 
 func (iClient *Client) splitYAML(yamlContents string) ([]string, error) {

--- a/linkerd/yaml.go
+++ b/linkerd/yaml.go
@@ -68,7 +68,6 @@ func (d *YAMLDecoder) Close() error {
 }
 
 const yamlSeparator = "\n---"
-const separator = "---"
 
 // splitYAMLDocument is a bufio.SplitFunc for splitting YAML streams into individual documents.
 func splitYAMLDocument(data []byte, atEOF bool) (advance int, token []byte, err error) {


### PR DESCRIPTION
Fixes #40 
I asked on Slack if we should maybe switch to using linkerd **stable** versions instead of **edge**. Or even better  - allow user to choose.
Anyway - currently the installation is broken and this fixes it.
