### PR TITLE
Add the safe close function for io operation and log error message.

### DIFF
--- a/pkg/util/io_util.go
+++ b/pkg/util/io_util.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Layer5.io
+// Copyright 2020 Layer5.io
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/util/io_util.go
+++ b/pkg/util/io_util.go
@@ -1,0 +1,29 @@
+// Copyright 2019 Layer5.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"io"
+
+	"github.com/sirupsen/logrus"
+)
+
+// SafeClose is a helper function help to close the io
+func SafeClose(co io.Closer, err *error) {
+	if cerr := co.Close(); cerr != nil && *err == nil {
+		*err = cerr
+		logrus.Error(cerr)
+	}
+}

--- a/pkg/util/io_util_test.go
+++ b/pkg/util/io_util_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Layer5.io
+// Copyright 2020 Layer5.io
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/util/io_util_test.go
+++ b/pkg/util/io_util_test.go
@@ -1,0 +1,37 @@
+// Copyright 2019 Layer5.io
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSafeClose(t *testing.T) {
+	f, err := os.Create("test_safe_close.txt")
+
+	SafeClose(f, &err)
+
+	if err != nil {
+		t.Errorf("Close function is failed")
+	}
+
+	err = os.Remove("test_safe_close.txt")
+
+	if err != nil {
+		t.Errorf("Remove file test_safe_close.txt failed")
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Aisuko <urakiny@gmail.com>

As we discussed under PR #46 we add the util function for `defer io close`. This is made more sense than before, the util function includes close the io and log the err message