### PR TITLE
modified install command to force to ignore cluster

### DIFF
--- a/linkerd/install.go
+++ b/linkerd/install.go
@@ -66,14 +66,14 @@ func (linkerd *Linkerd) fetchManifest(version string, isDel bool) (string, error
 	if err != nil {
 		return "", ErrFetchManifest(err, err.Error())
 	}
-	execCmd := "install"
+	execCmd := []string{"install", "--ignore-cluster"}
 	if isDel {
-		execCmd = "uninstall"
+		execCmd = []string{"uninstall"}
 	}
 
 	// We need a variable executable here hence using nosec
 	// #nosec
-	command := exec.Command(Executable, execCmd)
+	command := exec.Command(Executable, execCmd...)
 	command.Stdout = &out
 	command.Stderr = &er
 	err = command.Run()


### PR DESCRIPTION
**Description**
Linkerd binary needs kubeconfig to check cluster for the configuration. This behavior results in an error inside the containers where the binary does not have access to the kubeconfig. This PR adds a "--ignore-cluster" flag to the linkerd binary to avoid such erroneous behavior. 

Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>