### PR TITLE
Fix: linkerd uninstallation inside the container

### DIFF
--- a/linkerd/install.go
+++ b/linkerd/install.go
@@ -66,7 +66,7 @@ func (linkerd *Linkerd) fetchManifest(version string, isDel bool) (string, error
 	if err != nil {
 		return "", ErrFetchManifest(err, err.Error())
 	}
-	execCmd := []string{"install", "--ignore-cluster"}
+	execCmd := []string{"install"}
 	if isDel {
 		execCmd = []string{"uninstall"}
 	}

--- a/main.go
+++ b/main.go
@@ -40,16 +40,6 @@ func init() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-
-	err := os.Setenv("KUBECONFIG", path.Join(
-		config.KubeConfig[configprovider.FilePath],
-		fmt.Sprintf("%s.%s", config.KubeConfig[configprovider.FileName], config.KubeConfig[configprovider.FileType])),
-	)
-
-	if err != nil {
-		// Fail silently
-		fmt.Println(err)
-	}
 }
 
 // main is the entrypoint of the adaptor
@@ -61,6 +51,17 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
+	}
+
+	// Set $KUBECONFIG environmental variable
+	// crucial when adapter's running within the containers
+	err = os.Setenv("KUBECONFIG", path.Join(
+		config.KubeConfig[configprovider.FilePath],
+		fmt.Sprintf("%s.%s", config.KubeConfig[configprovider.FileName], config.KubeConfig[configprovider.FileType])),
+	)
+	if err != nil {
+		// Fail silently
+		log.Error(err)
 	}
 
 	// Initialize application specific configs and dependencies

--- a/main.go
+++ b/main.go
@@ -41,10 +41,15 @@ func init() {
 		os.Exit(1)
 	}
 
-	os.Setenv("KUBECONFIG", path.Join(
+	err := os.Setenv("KUBECONFIG", path.Join(
 		config.KubeConfig[configprovider.FilePath],
 		fmt.Sprintf("%s.%s", config.KubeConfig[configprovider.FileName], config.KubeConfig[configprovider.FileType])),
 	)
+
+	if err != nil {
+		// Fail silently
+		fmt.Println(err)
+	}
 }
 
 // main is the entrypoint of the adaptor

--- a/main.go
+++ b/main.go
@@ -40,6 +40,11 @@ func init() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+
+	os.Setenv("KUBECONFIG", path.Join(
+		config.KubeConfig[configprovider.FilePath],
+		fmt.Sprintf("%s.%s", config.KubeConfig[configprovider.FileName], config.KubeConfig[configprovider.FileType])),
+	)
 }
 
 // main is the entrypoint of the adaptor

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 	)
 	if err != nil {
 		// Fail silently
-		log.Error(err)
+		log.Warn(err)
 	}
 
 	// Initialize application specific configs and dependencies


### PR DESCRIPTION
**Description**
Linkerd uninstallation was failing if the "KUBECONFIG" environmental variable was not present. This PR handles that issue by setting the "KUBECONFIG" before booting up the server.

Tests done:
- [x] Linkerd installation outside the container
- [x] Linkerd uninstallation outside the container
- [x] Linkerd installation within the container
- [x] Linkerd uninstallation within the container

Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>