### PR TITLE
add feature to apply custom operation

### DIFF
--- a/linkerd/custom_operation.go
+++ b/linkerd/custom_operation.go
@@ -1,0 +1,16 @@
+package linkerd
+
+import (
+	"github.com/layer5io/meshery-adapter-library/status"
+)
+
+func (linkerd *Linkerd) applyCustomOperation(namespace string, manifest string, isDel bool) (string, error) {
+	st := status.Starting
+
+	err := linkerd.applyManifest([]byte(manifest), isDel, namespace)
+	if err != nil {
+		return st, ErrCustomOperation(err)
+	}
+
+	return status.Completed, nil
+}

--- a/linkerd/error.go
+++ b/linkerd/error.go
@@ -7,15 +7,16 @@ import (
 )
 
 var (
-	ErrInstallLinkerdCode = "linkerd_test_code"
-	ErrMeshConfigCode     = "linkerd_test_code"
-	ErrFetchManifestCode  = "linkerd_test_code"
-	ErrDownloadBinaryCode = "linkerd_test_code"
-	ErrInstallBinaryCode  = "linkerd_test_code"
-	ErrClientConfigCode   = "linkerd_test_code"
-	ErrClientSetCode      = "linkerd_test_code"
-	ErrStreamEventCode    = "linkerd_test_code"
-	ErrSampleAppCode      = "linkerd_test_code"
+	ErrInstallLinkerdCode  = "linkerd_test_code"
+	ErrMeshConfigCode      = "linkerd_test_code"
+	ErrFetchManifestCode   = "linkerd_test_code"
+	ErrDownloadBinaryCode  = "linkerd_test_code"
+	ErrInstallBinaryCode   = "linkerd_test_code"
+	ErrClientConfigCode    = "linkerd_test_code"
+	ErrClientSetCode       = "linkerd_test_code"
+	ErrStreamEventCode     = "linkerd_test_code"
+	ErrSampleAppCode       = "linkerd_test_code"
+	ErrCustomOperationCode = "linkerd_test_code"
 
 	ErrOpInvalid = errors.NewDefault(errors.ErrOpInvalid, "Invalid operation")
 )
@@ -63,4 +64,9 @@ func ErrStreamEvent(err error) error {
 // ErrSampleApp is the error for streaming event
 func ErrSampleApp(err error) error {
 	return errors.NewDefault(ErrSampleAppCode, fmt.Sprintf("Error with sample app operation: %s", err.Error()))
+}
+
+// ErrCustomOperation is the error for streaming event
+func ErrCustomOperation(err error) error {
+	return errors.NewDefault(ErrCustomOperationCode, fmt.Sprintf("Error with custom operation: %s", err.Error()))
 }

--- a/linkerd/linkerd.go
+++ b/linkerd/linkerd.go
@@ -87,6 +87,19 @@ func (linkerd *Linkerd) ApplyOperation(ctx context.Context, opReq adapter.Operat
 			ee.Details = ""
 			hh.StreamInfo(e)
 		}(linkerd, e)
+	case common.CustomOperation:
+		go func(hh *Linkerd, ee *adapter.Event) {
+			stat, err := hh.applyCustomOperation(opReq.Namespace, opReq.CustomBody, opReq.IsDeleteOperation)
+			if err != nil {
+				e.Summary = fmt.Sprintf("Error while %s custom operation", stat)
+				e.Details = err.Error()
+				hh.StreamErr(e, err)
+				return
+			}
+			ee.Summary = fmt.Sprintf("custom operation %s successfully", stat)
+			ee.Details = fmt.Sprintf("Custom operation %s successfully", stat)
+			hh.StreamInfo(e)
+		}(linkerd, e)
 	default:
 		linkerd.StreamErr(e, ErrOpInvalid)
 	}


### PR DESCRIPTION
**Description**
This PR adds the feature to support applying custom operations.

Tests Done:
_All the tests were done when adapter was running within the container_
- [x] Installing linkerd
- [x] Uninstalling linkerd
- [x] Applying custom yaml for deployments and services
- [x] Applying custom yaml for deployments and services in custom namespace
- [x] Applying custom yaml for deployments and services in a custom namespace with annotation `linkerd.io/inject: enabled`. Deployments were meshed successfully.
- [x] Deleting the deployments by applying custom yaml


Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>