### PR TITLE
Fixes #166. Use distroless as base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13 as build-env
+FROM golang:1.15 as build-env
 WORKDIR /github.com/layer5io/meshery-linkerd
 COPY go.mod go.sum ./
 RUN go mod download
@@ -9,7 +9,7 @@ COPY linkerd/ linkerd/
 
 RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags="-w -s" -a -o meshery-linkerd main.go
 
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/base:nonroot-amd64
 ENV DISTRO="debian"
 ENV GOARCH="amd64"
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags="-w -
 FROM gcr.io/distroless/base:nonroot-amd64
 ENV DISTRO="debian"
 ENV GOARCH="amd64"
-WORKDIR /
+WORKDIR /$HOME/.meshery
 COPY --from=build-env /github.com/layer5io/meshery-linkerd/meshery-linkerd .
-ENTRYPOINT ["/meshery-linkerd"]
+ENTRYPOINT ["./meshery-linkerd"]


### PR DESCRIPTION
Update Dockerfile to use distroless as base image. Brings down the image size from 95.5MB to 59.7MB.
Fixes #166 