### PR TITLE
[ci] Migrate golangci-lint config to v2 format and enforce linting

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -11,13 +11,23 @@ on:
       - '.github/**'
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v6
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: latest
+
   build:
     name: Build check
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    
-    # needs: [lint, error_check, static_check, vet, sec_check, tests]
+    needs: [lint] 
     steps:
     - name: Check out code
       uses: actions/checkout@v6

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,6 @@
 linters-settings:
+  staticcheck:
+    checks: ["all", "-ST1005"]
   gci:
     enabled: true
     max-len: 120
@@ -49,6 +51,7 @@ linters:
     - unused
     - cyclop
     - scopelint
+    - staticcheck
   exclude-rules:
     - testpackage
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,66 +1,39 @@
+version: 2
+
+run:
+  timeout: 5m
+  skip-dirs:
+    - vendor
+    - hack
+    - helpers
+    - bundle
+    - config
+    - img
+
 linters-settings:
   staticcheck:
     checks: ["all", "-ST1005"]
-  gci:
-    enabled: true
-    max-len: 120
-    line-length: 120
-  goconst:
-    enabled: true
-  gocritic:
-    enabled: true
-    disable:
-      - parallelize
-      - nesting
-      - hugeParam
-      - hugeStruct
-      - nestParam
-      - prealloc
   govet:
-    enabled: true
-    check-shadowing: true
-    tests: true
-  golint:
-    enabled: true
-    min-confidence: 0.8
-  unused:
-    enabled: true
-    check-exported: true
-    check-packages: true
-    check-generated: true
-    tests: true
-    allow-unused-type-export: true
-  cyclop:
-    enabled: true
-    average-strictness: 7
-  scopelint:
-    enabled: true
-    tests: true
+    check-shadowing: false
+  lll:
+    line-length: 120
 
-
-# Configuration for golangci-lint that is suitable for a Kubernetes operator project built with Golang
 linters:
-  enable-all: false
-  disable-all: false
-  linters:
-    - gci
-    - goconst
-    - gocritic
+  disable-all: true
+  enable:
+    - errcheck
+    - gofmt
+    - goimports
     - govet
-    - golint
-    - unused
-    - cyclop
-    - scopelint
+    - misspell
     - staticcheck
-  exclude-rules:
-    - testpackage
+    - stylecheck
+    - whitespace
+    - unused
+    - revive
 
-run:
-  enable-cache: true
-  skip-dirs:
-    - vendor
-    - bundle
-    - config
-    - hack
-    - helpers
-    - img
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - errcheck


### PR DESCRIPTION
### Description
This PR migrates the `.golangci.yml` configuration to version 2 and updates the GitHub Actions workflow to include a mandatory linting check. This ensures that the Linkerd adapter adheres to the latest code quality standards established across the Meshery ecosystem.

### Notes for Reviewers
* Upgraded `.golangci.yml` to `version: 2`.
* Added a `lint` job to the `build-and-release.yml` workflow.
* Configured the `build` job to depend on the `lint` job (`needs: [lint]`).
* Globally disabled the `ST1005` rule (standard for Meshery error messages).
* Verified that the Developer Certificate of Origin (DCO) is signed.

### Signed commits
- [x] Yes, I signed my commits.