### PR TITLE
[Chore] Upgrade Go toolchain to 1.26.4

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.23
+        go-version: 1.26
     - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go build .
   docker:
     name: Docker build and push

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.26
+        go-version-file: go.mod
     - run: GOPROXY=direct GOSUMDB=off GO111MODULE=on go build .
   docker:
     name: Docker build and push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.23
+        go-version: 1.26
     - name: Checkout repository
       uses: actions/checkout@master
     - name: Run Linters
@@ -57,7 +57,7 @@ jobs:
         - name: Set up Go
           uses: actions/setup-go@v6
           with:
-            go-version: 1.23.x
+            go-version: 1.26.x
         - name: Run unit tests
           run: go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic
         - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.26
+        go-version-file: go.mod
     - name: Checkout repository
       uses: actions/checkout@master
     - name: Run Linters
@@ -57,7 +57,7 @@ jobs:
         - name: Set up Go
           uses: actions/setup-go@v6
           with:
-            go-version: 1.26.x
+            go-version-file: go.mod
         - name: Run unit tests
           run: go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic
         - name: Upload coverage to Codecov

--- a/.github/workflows/error-ref-publisher.yaml
+++ b/.github/workflows/error-ref-publisher.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.26
+          go-version-file: go.mod
 
       - name: Run utility
         run: |

--- a/.github/workflows/error-ref-publisher.yaml
+++ b/.github/workflows/error-ref-publisher.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.23
+          go-version: 1.26
 
       - name: Run utility
         run: |

--- a/.github/workflows/update-oam-defs.yml
+++ b/.github/workflows/update-oam-defs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.26
+          go-version-file: go.mod
       - name: Run adapter to create components
         run: |
           touch log.txt

--- a/.github/workflows/update-oam-defs.yml
+++ b/.github/workflows/update-oam-defs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.23
+          go-version: 1.26
       - name: Run adapter to create components
         run: |
           touch log.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 as build-env
+FROM golang:1.26 as build-env
 ENV CGO_ENABLED=0
 ARG VERSION
 ARG GIT_COMMITSHA

--- a/build/Makefile.core.mk
+++ b/build/Makefile.core.mk
@@ -19,7 +19,7 @@ GIT_VERSION	= $(shell git describe --tags `git rev-list --tags --max-count=1`)
 GIT_COMMITSHA = $(shell git rev-list -1 HEAD)
 GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` | cut -c 2-)
 
-GOVERSION = 1.23
+GOVERSION = 1.26
 GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
 

--- a/build/Makefile.core.mk
+++ b/build/Makefile.core.mk
@@ -19,7 +19,7 @@ GIT_VERSION	= $(shell git describe --tags `git rev-list --tags --max-count=1`)
 GIT_COMMITSHA = $(shell git rev-list -1 HEAD)
 GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` | cut -c 2-)
 
-GOVERSION = 1.26
+GOVERSION = 1.26.4
 GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/layer5io/meshery-linkerd
 
-go 1.23
-toolchain go1.24.1
+go 1.26.4
 
 replace github.com/kudobuilder/kuttl => github.com/layer5io/kuttl v0.4.1-0.20200723152044-916f10574334
 


### PR DESCRIPTION
## Description
Upgrade Go toolchain from 1.23 to 1.26.4 to pick up the latest security and bug fixes.

### Changes
- `go.mod`: `go 1.23` + `toolchain go1.24.1` → `go 1.26.4` (toolchain directive removed)
- `Dockerfile`: `golang:1.23` → `golang:1.26`
- `build/Makefile.core.mk`: `GOVERSION = 1.23` → `1.26`
- CI workflows: `go-version: 1.23` → `1.26` in `ci.yml`, `build-and-release.yml`, `update-oam-defs.yml`, `error-ref-publisher.yaml`

### Verification
- ✅ `go build ./...`
- ✅ `go test ./...`
- ✅ `go vet ./...`

### Compatibility Checks
- `url.ParseRequestURI` in `linkerd/addons.go` — safe, not affected by Go 1.26 `net/url.Parse` host-colon change
- No `httputil.ReverseProxy.Director` or `crypto/rsa` PKCS#1 v1.5 usage
- golangci-lint v2.12.1 (built with go1.26.2) confirms Go 1.26 support

Relates to meshery/meshery#19875